### PR TITLE
fix: add header blocks for jekyll on inclusion

### DIFF
--- a/simulation_production_strategy.md
+++ b/simulation_production_strategy.md
@@ -1,3 +1,11 @@
+---
+title: ePIC Simulation Production Strategy
+name: simulation_production_strategy
+layout: default
+---
+
+{% include layouts/title.md %}
+
 # ePIC Simulation Production Strategy
 Versions:
 - 1.0; [source as approved](https://docs.google.com/document/d/16PWnAVpR9qhymDkzAmmEnmzhswJy9SB0s0C7fW89-Lo/edit)

--- a/source_code_management.md
+++ b/source_code_management.md
@@ -1,3 +1,11 @@
+---
+title: ePIC Source Code Management
+name: source_code_management
+layout: default
+---
+
+{% include layouts/title.md %}
+
 # Recommendations: ePIC Source Code Management
 Versions:
 - 1.0; [source as approved](https://docs.google.com/document/d/1pM2R6TnegUMKxdODPKLVQLcIogozdWXcPv1--2IIyEU/edit?usp=sharing)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds md headers so we can include this in eic.github.io more easily.
